### PR TITLE
Add route-nopull

### DIFF
--- a/openvpn-config.sh
+++ b/openvpn-config.sh
@@ -392,6 +392,7 @@ rcvbuf 0
 remote $IP $PORT
 resolv-retry infinite
 nobind
+route-nopull
 persist-key
 persist-tun
 remote-cert-tls server


### PR DESCRIPTION
This prevents the client from routing all Internet traffic over the VPN (via 0.0.0.0/1 and 128.0.0.0/1 routes), and instead only routes traffic to 10.8.0.0/24 across it.